### PR TITLE
Updates Dec 2022

### DIFF
--- a/custom_components/magiqtouch/climate.py
+++ b/custom_components/magiqtouch/climate.py
@@ -77,7 +77,7 @@ SUPPORT_FLAGS = SUPPORT_TARGET_TEMPERATURE | SUPPORT_FAN_MODE  # | SUPPORT_PRESE
 
 HVAC_MODES = [HVAC_MODE_OFF, HVAC_MODE_COOL, HVAC_MODE_FAN_ONLY, HVAC_MODE_HEAT, HVAC_MODE_AUTO]
 
-FAN_SPEED_AUTO = "auto"
+FAN_SPEED_AUTO = "Temperature"
 FAN_SPEEDS = [str(spd+1) for spd in range(10)] + [FAN_SPEED_AUTO]
 
 
@@ -344,14 +344,13 @@ class MagiQtouch(CoordinatorEntity, ClimateEntity):
         return speed
 
     async def async_set_fan_mode(self, fan_mode):
-        if fan_mode == FAN_SPEED_AUTO:
-            fan_mode = 0
-
-        elif str(fan_mode) not in FAN_SPEEDS:
+        if str(fan_mode) not in FAN_SPEEDS:
             _LOGGER.warning("Unknown fan speed: %s" % fan_mode)
 
         else:
             _LOGGER.debug("Set fan to: %s" % fan_mode)
+            if fan_mode == FAN_SPEED_AUTO:
+                fan_mode = 0
             await self.controller.set_current_speed(fan_mode)
 
         await self.coordinator.async_request_refresh()
@@ -396,3 +395,4 @@ class MagiQtouch(CoordinatorEntity, ClimateEntity):
     #         self.controller.refresh_state()
     #     except Exception as ex:
     #         _LOGGER.warning("Updating the state failed: %s" % ex)
+

--- a/custom_components/magiqtouch/climate.py
+++ b/custom_components/magiqtouch/climate.py
@@ -154,10 +154,9 @@ class MagiQtouchCoordinator(DataUpdateCoordinator):
             await self.controller.login()
 
 class MagiQtouch(CoordinatorEntity, ClimateEntity):
-    """Representation of an Awesome Light."""
+    """Representation of an MagIQtouch Thermostat."""
 
     def __init__(self, entry_id, controller: MagiQtouch_Driver, coordinator: MagiQtouchCoordinator, zone_index):
-        """Initialize an AwesomeLight."""
         super().__init__(coordinator)
         self.controller = controller
         self.zone_index = zone_index

--- a/custom_components/magiqtouch/climate.py
+++ b/custom_components/magiqtouch/climate.py
@@ -272,7 +272,8 @@ class MagiQtouch(CoordinatorEntity, ClimateEntity):
             _LOGGER.debug(f"hvac_mode: (CFanOnlyOrCool) {HVAC_MODE_FAN_ONLY}")
             return HVAC_MODE_FAN_ONLY
         temperature_mode = self.controller.current_state.FanOrTempControl
-        if temperature_mode:
+        evap_cooling_mode = self.controller.current_state.PumpStatus
+        if evap_cooling_mode:
             _LOGGER.debug(f"hvac_mode: {HVAC_MODE_COOL}")
             return HVAC_MODE_COOL
         heating_running = self.controller.current_state.HRunning
@@ -334,6 +335,9 @@ class MagiQtouch(CoordinatorEntity, ClimateEntity):
     @property
     def fan_mode(self):
         """Return the current fan modes."""
+        if self.controller.current_state.FanOrTempControl == 1:
+             # running in temperature set point mode
+             return FAN_SPEED_AUTO
         speed = str(self.controller.current_state.CFanSpeed)
         if speed == "0":
             return FAN_SPEED_AUTO

--- a/custom_components/magiqtouch/const.py
+++ b/custom_components/magiqtouch/const.py
@@ -4,3 +4,5 @@ DOMAIN = "magiqtouch"
 
 FAN_MIN = 'min'
 FAN_MAX = 'max'
+
+CONF_VERBOSE = "log_json"

--- a/custom_components/magiqtouch/magiqtouch.py
+++ b/custom_components/magiqtouch/magiqtouch.py
@@ -341,8 +341,10 @@ def main():
 
     while not m.current_state:
         time.sleep(1)
-    pp(m.current_state.__as_dict__())
-
+    print("")
+    print("Current State:")
+    print(str(m.current_state))
+    print("")
 
 if __name__ == "__main__":
     main()

--- a/custom_components/magiqtouch/magiqtouch.py
+++ b/custom_components/magiqtouch/magiqtouch.py
@@ -17,6 +17,7 @@ import aiobotocore
 import threading
 import requests
 import aiohttp
+from pprint import pp
 from mandate import Cognito
 from datetime import datetime
 from botocore.errorfactory import BaseClientExceptions
@@ -385,7 +386,7 @@ def main():
 
     while not m.current_state:
         time.sleep(1)
-    print(m.current_state)
+    pp(m.current_state.__as_dict__())
 
 
 if __name__ == "__main__":

--- a/custom_components/magiqtouch/manifest.json
+++ b/custom_components/magiqtouch/manifest.json
@@ -1,6 +1,6 @@
 { 
   "domain": "magiqtouch",
-  "name": "Seeley MagiQtouch",
+  "name": "Seeley MagIQtouch",
   "config_flow": true,
   "documentation": "https://gitlab.com/alelec/ha_magiqtouch",
   "issue_tracker": "https://gitlab.com/alelec/ha_magiqtouch/-/issues",

--- a/custom_components/magiqtouch/structures.py
+++ b/custom_components/magiqtouch/structures.py
@@ -192,6 +192,26 @@ class RemoteStatus(Structure):
     SetTempZone10 = 0
     ActualTempZone10 = 0
     
+    def __eq__(self, other):
+        if not isinstance(other, RemoteStatus):
+            return False
+        s = self.__as_dict__()
+        o = other.__as_dict__()
+        
+        for key in list(s.keys()):
+            if "Actual" in key:
+                s.pop(key)
+                o.pop(key)
+            elif key in (
+                "DateKey",
+                "TimeKey",
+                "TimeRunning",
+                "SignalStrength",
+            ):
+                s.pop(key)
+                o.pop(key)
+        return s == o
+        
     def __str__(self):
         return json.dumps(self.__as_dict__())
 

--- a/custom_components/magiqtouch/structures.py
+++ b/custom_components/magiqtouch/structures.py
@@ -1,4 +1,4 @@
-
+import json
 from dataclasses import dataclass, field
 import inspect
 from structured_config import Structure, IntField, StrField
@@ -191,6 +191,10 @@ class RemoteStatus(Structure):
     ProgramModeOverriddenZone10 = 0
     SetTempZone10 = 0
     ActualTempZone10 = 0
+    
+    def __str__(self):
+        return json.dumps(self.__as_dict__())
+
 
 @dataclass
 class SystemDetails:

--- a/custom_components/magiqtouch/translations/en.json
+++ b/custom_components/magiqtouch/translations/en.json
@@ -19,5 +19,15 @@
             }
         }
     },
-    "title": "Seeley MagiQtouch"
+  "options": {
+    "step": {
+      "init": {
+        "title": "Settings",
+        "data": {
+          "log_json": "Log the sent and received json data when anything is changed."
+        }
+      }
+    }
+  },
+  "title": "Seeley MagiQtouch"
 }

--- a/custom_components/magiqtouch/translations/en.json
+++ b/custom_components/magiqtouch/translations/en.json
@@ -15,7 +15,7 @@
                     "password": "Password",
                     "username": "Email / User"
                 },
-                "title": "Seeley MagiQtouch login"
+                "title": "Seeley MagIQtouch login"
             }
         }
     },
@@ -29,5 +29,5 @@
       }
     }
   },
-  "title": "Seeley MagiQtouch"
+  "title": "Seeley MagIQtouch"
 }


### PR DESCRIPTION
* Fix spelling of MagIQtouch.
* Add optional setting to log sent/received json data.
* cli: print current state as json
* Use custom fan settings to switch between fan/temp modes when cooling.
* Fix hvac_mode vs hvac_action for evap cool/idle.
* Consolidate use and auto-renew auth tokens.
* Non-Fan Speed-Mode labelled Temperature rather than Auto
* Cleanup obsolete / unnecessary mqtt login.
* improve print from command line testing
* Improve cool vs fan modes for evap cooler
* Fast refresh for period after set functions
* Migrate set functions to asyncio and use ha.helpers.aiohttp_client
