### PR TITLE
Fixup breaking changes on 2025.1, Async issues and current deprecations

### DIFF
--- a/custom_components/magiqtouch/__init__.py
+++ b/custom_components/magiqtouch/__init__.py
@@ -62,8 +62,8 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry):
     # driver.set_verbose(entry.options.get(CONF_VERBOSE, False), initial=True)
     await driver.startup(hass)
     # await coordinator.async_config_entry_first_refresh()
-    for component in PLATFORMS:
-        hass.async_create_task(hass.config_entries.async_forward_entry_setup(entry, component))
+    # 2025.1 Depracates async_forward_entry_setup, replace with new method
+    await hass.config_entries.async_forward_entry_setups(entry, PLATFORMS)
     # listen for changes to the configuration options
     entry.async_on_unload(entry.add_update_listener(options_update_listener))
     return True

--- a/custom_components/magiqtouch/climate.py
+++ b/custom_components/magiqtouch/climate.py
@@ -21,7 +21,7 @@ from homeassistant.components.climate import (
 )
 from homeassistant.helpers.entity import Entity
 from homeassistant.config_entries import ConfigEntry
-from homeassistant.helpers.typing import HomeAssistantType
+from homeassistant.core import HomeAssistant
 from homeassistant.helpers.update_coordinator import (
     CoordinatorEntity,
 )
@@ -78,7 +78,7 @@ PRESET_COOL_FAN_SPEED = "Cooling: set fan speed"
 
 
 async def async_setup_entry(
-    hass: HomeAssistantType,
+    hass: HomeAssistant,
     entry: ConfigEntry,
     async_add_entities: Callable[[List[Entity], bool], None],
 ) -> None:

--- a/custom_components/magiqtouch/magiqtouch.py
+++ b/custom_components/magiqtouch/magiqtouch.py
@@ -352,7 +352,8 @@ class MagiQtouch_Driver:
             raise
 
     async def _get_token(self):
-        await self._cognito.check_token(renew=True)
+        # Cognito isn't fully Async. Boto3 is eventually used and has blocking IO
+        await asyncio.to_thread(asyncio.run, self._cognito.check_token(renew=True))
         return self._cognito.id_token
 
     async def _get_auth(self, token=None):

--- a/custom_components/magiqtouch/magiqtouch.py
+++ b/custom_components/magiqtouch/magiqtouch.py
@@ -156,7 +156,9 @@ class MagiQtouch_Driver:
                 secret_key="wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY",
             )
 
-            await self._cognito.authenticate(self._password)
+            # Cognito.authenticate() isn't fully Async. Boto3 is eventually used and has blocking IO
+            await asyncio.to_thread(asyncio.run, self._cognito.authenticate(self._password))
+
         except Exception as ex:
             if "UserNotFoundException" in str(ex) or "NotAuthorizedException" in str(ex):
                 _LOGGER.exception("Error with login email/password", ex)

--- a/custom_components/magiqtouch/sensor.py
+++ b/custom_components/magiqtouch/sensor.py
@@ -13,7 +13,7 @@ from homeassistant.components.sensor import (
 )
 from homeassistant.helpers.entity import Entity
 from homeassistant.config_entries import ConfigEntry
-from homeassistant.helpers.typing import HomeAssistantType
+from homeassistant.core import HomeAssistant
 from homeassistant.core import callback
 from homeassistant.helpers.update_coordinator import (
     CoordinatorEntity,
@@ -36,7 +36,7 @@ _LOGGER = logging.getLogger("magiqtouch")
 
 
 async def async_setup_entry(
-    hass: HomeAssistantType,
+    hass: HomeAssistant,
     entry: ConfigEntry,
     async_add_entities: Callable[[List[Entity], bool], None],
 ) -> None:


### PR DESCRIPTION
Just enough fixes code to enable use in 2025.1 as raised in #30 

Two main issues causing the failure:

1. Use of async_forward_entry_setup was removed in 2025.1
2. cognito.authenticate() contains blocking IO calls. Traced to aioboto3.
3. Also cleaned up use of HomeAssistantType which will be deprecated soon.

This is just enough to get it going on my setup. I have not fully tested all possible commands, what I have tested works so far.
Current setup has Evap+Heater no Zones

